### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,4 +1,6 @@
 name: Build and Push Docker Image
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/zamalali/langchain-code/security/code-scanning/1](https://github.com/zamalali/langchain-code/security/code-scanning/1)

To fix the problem, explicitly specify the GitHub Actions `permissions` in the workflow file. In general, set the `permissions` to the minimum necessary for the workflow to succeed. Review the steps: checking out code (actions/checkout) and interacting with Docker registry (docker/login-action, docker/build-push-action). These actions require only `contents: read` permission for checkout, as none of the steps perform git pushes or modify repository contents. Therefore, it is sufficient and secure to add `permissions: contents: read` at the workflow or job level. For simplicity and broadest least privilege, add the `permissions` block at the top level in `.github/workflows/docker-build.yml` just below the `name:` and before `on:`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
