### PR TITLE
build(pyproject): require Python >=3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "langchain-code"
 version = "0.0.1"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
     "click>=8.1.7,<9",
     "typer>=0.12.3",


### PR DESCRIPTION
## Fix Python version compatibility issue with deepagents dependency

**Problem:**
The project's pyproject.toml specified `requires-python = ">=3.10"`, but the `deepagents>=0.0.3` dependency requires Python `>=3.11,<4.0`. This version conflict prevented successful dependency resolution during `uv sync`, causing the build to fail with the error:

```
No solution found when resolving dependencies for split (markers: python_full_version == '3.10.*'):
Because the requested Python version (>=3.10) does not satisfy Python>=3.11,<4.0 and deepagents>=0.0.3 depends on Python>=3.11,<4.0
```

**Solution:**
Updated the Python requirement in pyproject.toml from `>=3.10` to `>=3.11` to align with the minimum version required by the `deepagents` package and ensure all dependencies can be resolved successfully.

**Changes:**
- Modified `requires-python` field in pyproject.toml from `">=3.10"` to `">=3.11"`

**Testing:**
- Verified that `uv sync` now completes successfully without dependency conflicts
- All 121 packages install correctly in the Python 3.11+ environment

**Impact:**
This change ensures compatibility with all project dependencies while maintaining support for modern Python versions. Users will need Python 3.11 or higher to run this project.